### PR TITLE
Fix: device not rebooting after successful flash

### DIFF
--- a/flash-live-remote
+++ b/flash-live-remote
@@ -138,6 +138,11 @@ TARGET_DEV="$1"
 DATA_PORT="$2"
 SIGNAL_PORT="$3"
 
+# Resolve binary paths now — after dd overwrites the disk, PATH lookups
+# against the rootfs may fail (page cache eviction under memory pressure).
+BUSYBOX=$(command -v busybox)
+DD=$(command -v dd)
+
 echo "flash-helper: starting (target=$TARGET_DEV, data=$DATA_PORT, signal=$SIGNAL_PORT)"
 
 # Stop services
@@ -148,7 +153,7 @@ sync
 # --- Handshake: signal readiness and wait for client confirmation ---
 # This happens BEFORE any destructive action so the device can recover if the client aborts.
 echo "flash-helper: signaling ready on port $SIGNAL_PORT..."
-REPLY=$(echo "READY" | busybox nc -l -p "$SIGNAL_PORT" -w 60)
+REPLY=$(echo "READY" | "$BUSYBOX" nc -l -p "$SIGNAL_PORT" -w 60)
 if [ "$REPLY" != "GO" ]; then
   echo "flash-helper: client did not confirm (got '$REPLY'), aborting"
   echo "flash-helper: rebooting to restore services..."
@@ -159,13 +164,13 @@ echo "flash-helper: client confirmed, starting listener"
 
 # --- Start nc|dd listener and wait for transfer ---
 echo "flash-helper: starting nc|dd listener on port $DATA_PORT -> $TARGET_DEV"
-busybox nc -l -p "$DATA_PORT" | dd of="$TARGET_DEV" bs=4M 2>/dev/shm/dd-status
+"$BUSYBOX" nc -l -p "$DATA_PORT" | "$DD" of="$TARGET_DEV" bs=4M 2>/dev/shm/dd-status
 echo "flash-helper: dd complete, status:"
 cat /dev/shm/dd-status 2>/dev/null || true
 sync
 
 echo "flash-helper: rebooting..."
-reboot -f
+"$BUSYBOX" reboot -f
 HELPER_EOF
 
 ssh -n "$host" "chmod +x /dev/shm/flash-helper.sh"


### PR DESCRIPTION
## Summary

- Resolve `busybox`, `dd` to absolute paths before starting the disk write
- Use the resolved paths for all operations that run after dd completes

## Root cause

After `dd` overwrites the entire block device, the old rootfs on disk is gone. The kernel's VFS page cache may still hold some directory entries and inodes, but after writing 7+ GB of image data, memory pressure can evict those cached entries. When the helper then tries to run `reboot -f`, the shell can't resolve it via PATH because the rootfs directories are no longer readable.

This was introduced when the tmpfs/busybox-symlinks setup was removed during PR review of halos-org/halos-pi-gen#68. The original design had busybox copied to tmpfs with reboot symlinks; removing that "dead code" broke the reboot path.

## Test plan

- [ ] Flash a device and verify it reboots automatically after transfer completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)