### PR TITLE
Add first-boot customization via --config

### DIFF
--- a/example.conf
+++ b/example.conf
@@ -1,0 +1,25 @@
+# flash-live-remote configuration file
+#
+# Simple key=value format. Comments start with #.
+# The value is everything after the first = sign — do NOT quote values.
+# Spaces are preserved as-is (e.g., wifi-ssid=My Network).
+# Tilde (~/) in ssh-key paths is expanded to your home directory.
+
+# System hostname
+hostname=myboat
+
+# Username (replaces default 'pi')
+user=mairas
+
+# User password (hashed locally with openssl before transfer)
+password=secret123
+
+# SSH public key files (repeatable — list each on its own line)
+# If user is set and no ssh-key lines are present, ~/.ssh/*.pub is used automatically.
+ssh-key=~/.ssh/id_ed25519.pub
+ssh-key=~/.ssh/id_rsa.pub
+
+# WiFi configuration (both ssid and password are required together)
+wifi-ssid=MyNetwork
+wifi-password=MyWifiPass
+wifi-country=FI

--- a/flash-live-remote
+++ b/flash-live-remote
@@ -87,8 +87,6 @@ if [ $# -lt 2 ]; then
   echo "First-boot customization:" >&2
   echo "  --config FILE      Config file with key=value settings for first-boot customization." >&2
   echo "                     See example.conf for available keys and format." >&2
-  echo "                     Requires the new image to have the same partition layout as the" >&2
-  echo "                     running image (boot partition = partition 1)." >&2
   echo "" >&2
   echo "Supported formats: .img, .img.xz, .img.gz" >&2
   echo "" >&2
@@ -99,7 +97,7 @@ if [ $# -lt 2 ]; then
   echo "" >&2
   echo "Prerequisites:" >&2
   echo "  Local:  ssh, scp, xzcat/zcat (for compressed images)" >&2
-  echo "  Target: busybox (with mount, umount applets for customization)" >&2
+  echo "  Target: busybox (with fdisk, losetup, mount, umount applets for customization)" >&2
   exit 1
 fi
 
@@ -188,7 +186,7 @@ fi
 password_hash=""
 if [ -n "$custom_password" ]; then
   _require openssl
-  password_hash=$(echo "$custom_password" | openssl passwd -6 -stdin)
+  password_hash=$(printf '%s' "$custom_password" | openssl passwd -6 -stdin)
 fi
 
 has_customization=false
@@ -348,6 +346,14 @@ if [ "$has_customization" = true ]; then
     echo "Error: kernel on $host lacks vfat support (required for customization)" >&2
     exit 1
   fi
+
+  # Verify busybox has required applets for loop-mount boot partition
+  for applet in fdisk losetup; do
+    if ! ssh -n "$host" "busybox $applet --help" >/dev/null 2>&1; then
+      echo "Error: busybox on $host lacks $applet applet (required for customization)" >&2
+      exit 1
+    fi
+  done
 fi
 
 # --- Confirmation prompt ---
@@ -433,14 +439,20 @@ DECOMPRESS_CMD="$3"
 
 # Resolve all binary paths now — after dd overwrites the disk, PATH lookups
 # against the rootfs may fail (page cache eviction under memory pressure).
-BUSYBOX=$(command -v busybox)
+BUSYBOX_SRC=$(command -v busybox)
 DD=$(command -v dd)
 DECOMPRESS=$(command -v "$DECOMPRESS_CMD")
 
-# Reboot on exit — if decompression fails before dd, the old image is intact
-# and the device recovers. If dd fails mid-write, the device is bricked either
-# way but at least it reboots so the user knows something happened.
-trap '"$BUSYBOX" reboot -f' EXIT
+# Copy busybox to tmpfs — after dd, busybox's text pages can be evicted
+# from cache and the kernel will try to page them back from the overwritten
+# disk, causing SIGBUS. Tmpfs is RAM-backed so pages are never evicted.
+cp "$BUSYBOX_SRC" /dev/shm/busybox
+chmod +x /dev/shm/busybox
+BUSYBOX=/dev/shm/busybox
+
+# Reboot on exit with sysrq fallback — if busybox reboot fails for any
+# reason, sysrq-trigger forces an immediate hardware reboot.
+trap '"$BUSYBOX" reboot -f 2>/dev/null || { echo 1 > /proc/sys/kernel/sysrq; echo b > /proc/sysrq-trigger; }' EXIT
 
 echo "flash-helper: decompressing and writing $IMAGE_PATH -> $TARGET_DEV"
 "$DECOMPRESS" "$IMAGE_PATH" | "$DD" of="$TARGET_DEV" bs=4M 2>/dev/shm/dd-status
@@ -451,36 +463,54 @@ echo "flash-helper: dd complete:"
 
 # Apply first-boot customization if payload files were transferred.
 # Errors here must not abort — the image is already flashed successfully,
-# so we want to reboot regardless.
+# so we want to reboot regardless. Run in a subshell to isolate from set -e.
 if [ -f /dev/shm/custom-user-data ] || [ -f /dev/shm/custom-network-config ]; then
-  echo "flash-helper: applying first-boot customization..."
+  (
+    echo "flash-helper: applying first-boot customization..."
 
-  # Determine boot partition device name (mmcblk0p1 vs sda1).
-  # The kernel's old partition nodes are still valid — dd wrote a new
-  # partition table with the same layout, and the kernel keeps the stale
-  # entries until reboot. No blockdev --rereadpt needed (and it would
-  # fail anyway since the rootfs partition is still "in use").
-  BOOT_PART="${TARGET_DEV}p1"
-  "$BUSYBOX" test -b "$BOOT_PART" || BOOT_PART="${TARGET_DEV}1"
+    # Mount via loop device at the correct offset from the NEW partition table.
+    # After dd, the kernel still has stale partition nodes (old offsets/sizes)
+    # and stale block cache from the old image. Using the partition node would
+    # read/write at the wrong offset or serve cached data. Instead, parse the
+    # new partition table directly and create a loop device at the right offset.
+    #
+    # Busybox fdisk format (CHS columns precede LBA):
+    #   /dev/nvme0n1p1 *  128,0,1  1023,3,32  16384  1064959  1048576  512M c ...
+    # After stripping the optional boot flag (*), StartLBA is field 4.
+    PART1_LINE=$("$BUSYBOX" fdisk -l "$TARGET_DEV" 2>/dev/null \
+      | "$BUSYBOX" grep "^${TARGET_DEV}" | "$BUSYBOX" head -1)
+    PART1_START=$(echo "$PART1_LINE" | "$BUSYBOX" sed 's/\*//' | "$BUSYBOX" awk '{print $4}')
 
-  "$BUSYBOX" mkdir -p /dev/shm/bootmnt
-  if "$BUSYBOX" mount -t vfat "$BOOT_PART" /dev/shm/bootmnt; then
-    [ -f /dev/shm/custom-user-data ] && \
-      "$BUSYBOX" cp /dev/shm/custom-user-data /dev/shm/bootmnt/user-data
-    [ -f /dev/shm/custom-network-config ] && \
-      "$BUSYBOX" cp /dev/shm/custom-network-config /dev/shm/bootmnt/network-config
-    # Update regulatory domain in cmdline.txt to match WiFi country
-    if [ -f /dev/shm/custom-wifi-country ] && [ -f /dev/shm/bootmnt/cmdline.txt ]; then
-      REGDOM=$("$BUSYBOX" cat /dev/shm/custom-wifi-country | "$BUSYBOX" tr -d '[:space:]')
-      "$BUSYBOX" sed -i "s/cfg80211.ieee80211_regdom=[A-Z]*/cfg80211.ieee80211_regdom=$REGDOM/" /dev/shm/bootmnt/cmdline.txt
+    # Validate parsed offset — must be a positive integer
+    if ! echo "$PART1_START" | "$BUSYBOX" grep -qE '^[0-9]+$' || [ "$PART1_START" -eq 0 ]; then
+      echo "flash-helper: ERROR: failed to parse boot partition offset (got: '$PART1_START')"
+      exit 1
     fi
-    # umount flushes FAT32 data. No explicit sync — a global sync would risk
-    # writing back old rootfs dirty pages over the new image.
-    "$BUSYBOX" umount /dev/shm/bootmnt
-    echo "flash-helper: boot partition customization applied"
-  else
-    echo "flash-helper: ERROR: could not mount boot partition for customization"
-  fi
+    OFFSET=$((PART1_START * 512))
+
+    LOOP_DEV=$("$BUSYBOX" losetup -f)
+    "$BUSYBOX" losetup -o "$OFFSET" "$LOOP_DEV" "$TARGET_DEV"
+
+    "$BUSYBOX" mkdir -p /dev/shm/bootmnt
+    if "$BUSYBOX" mount -t vfat "$LOOP_DEV" /dev/shm/bootmnt; then
+      [ -f /dev/shm/custom-user-data ] && \
+        "$BUSYBOX" cp /dev/shm/custom-user-data /dev/shm/bootmnt/user-data
+      [ -f /dev/shm/custom-network-config ] && \
+        "$BUSYBOX" cp /dev/shm/custom-network-config /dev/shm/bootmnt/network-config
+      # Update regulatory domain in cmdline.txt to match WiFi country
+      if [ -f /dev/shm/custom-wifi-country ] && [ -f /dev/shm/bootmnt/cmdline.txt ]; then
+        REGDOM=$("$BUSYBOX" cat /dev/shm/custom-wifi-country | "$BUSYBOX" tr -d '[:space:]')
+        "$BUSYBOX" sed -i "s/cfg80211.ieee80211_regdom=[A-Z]*/cfg80211.ieee80211_regdom=$REGDOM/" /dev/shm/bootmnt/cmdline.txt
+      fi
+      # umount flushes FAT32 data. No explicit sync — a global sync would risk
+      # writing back old rootfs dirty pages over the new image.
+      "$BUSYBOX" umount /dev/shm/bootmnt
+      echo "flash-helper: boot partition customization applied"
+    else
+      echo "flash-helper: ERROR: could not mount boot partition for customization"
+    fi
+    "$BUSYBOX" losetup -d "$LOOP_DEV" 2>/dev/null || true
+  ) || echo "flash-helper: WARNING: customization failed, continuing to reboot"
 fi
 
 # EXIT trap handles reboot -f (skips sync so old rootfs cache doesn't
@@ -515,41 +545,61 @@ TARGET_DEV="$1"
 
 # Resolve all binary paths now — after dd overwrites the disk, PATH lookups
 # against the rootfs may fail (page cache eviction under memory pressure).
-BUSYBOX=$(command -v busybox)
+BUSYBOX_SRC=$(command -v busybox)
 DD=$(command -v dd)
 
-# Reboot when done (or on failure) — once dd starts, the rootfs is destroyed.
-trap '"$BUSYBOX" reboot -f' EXIT
+# Copy busybox to tmpfs (see ramfs helper for rationale).
+cp "$BUSYBOX_SRC" /dev/shm/busybox
+chmod +x /dev/shm/busybox
+BUSYBOX=/dev/shm/busybox
+
+# Reboot when done (or on failure) with sysrq fallback.
+trap '"$BUSYBOX" reboot -f 2>/dev/null || { echo 1 > /proc/sys/kernel/sysrq; echo b > /proc/sysrq-trigger; }' EXIT
 
 echo "flash-helper: writing stdin -> $TARGET_DEV"
 "$DD" of="$TARGET_DEV" bs=4M 2>/dev/shm/dd-status
 "$BUSYBOX" cat /dev/shm/dd-status 2>/dev/null || true
 echo "flash-helper: dd complete"
 
-# Apply first-boot customization if payload files were transferred
+# Apply first-boot customization if payload files were transferred.
+# Errors must not prevent reboot. Run in a subshell to isolate failures.
 if [ -f /dev/shm/custom-user-data ] || [ -f /dev/shm/custom-network-config ]; then
-  echo "flash-helper: applying first-boot customization..."
+  (
+    echo "flash-helper: applying first-boot customization..."
 
-  # See ramfs helper for explanation of why blockdev --rereadpt is skipped.
-  BOOT_PART="${TARGET_DEV}p1"
-  "$BUSYBOX" test -b "$BOOT_PART" || BOOT_PART="${TARGET_DEV}1"
+    # Mount via loop device at correct offset (see ramfs helper for rationale).
+    PART1_LINE=$("$BUSYBOX" fdisk -l "$TARGET_DEV" 2>/dev/null \
+      | "$BUSYBOX" grep "^${TARGET_DEV}" | "$BUSYBOX" head -1)
+    PART1_START=$(echo "$PART1_LINE" | "$BUSYBOX" sed 's/\*//' | "$BUSYBOX" awk '{print $4}')
 
-  "$BUSYBOX" mkdir -p /dev/shm/bootmnt
-  if "$BUSYBOX" mount -t vfat "$BOOT_PART" /dev/shm/bootmnt; then
-    [ -f /dev/shm/custom-user-data ] && \
-      "$BUSYBOX" cp /dev/shm/custom-user-data /dev/shm/bootmnt/user-data
-    [ -f /dev/shm/custom-network-config ] && \
-      "$BUSYBOX" cp /dev/shm/custom-network-config /dev/shm/bootmnt/network-config
-    # Update regulatory domain in cmdline.txt to match WiFi country
-    if [ -f /dev/shm/custom-wifi-country ] && [ -f /dev/shm/bootmnt/cmdline.txt ]; then
-      REGDOM=$("$BUSYBOX" cat /dev/shm/custom-wifi-country | "$BUSYBOX" tr -d '[:space:]')
-      "$BUSYBOX" sed -i "s/cfg80211.ieee80211_regdom=[A-Z]*/cfg80211.ieee80211_regdom=$REGDOM/" /dev/shm/bootmnt/cmdline.txt
+    # Validate parsed offset — must be a positive integer
+    if ! echo "$PART1_START" | "$BUSYBOX" grep -qE '^[0-9]+$' || [ "$PART1_START" -eq 0 ]; then
+      echo "flash-helper: ERROR: failed to parse boot partition offset (got: '$PART1_START')"
+      exit 1
     fi
-    "$BUSYBOX" umount /dev/shm/bootmnt
-    echo "flash-helper: boot partition customization applied"
-  else
-    echo "flash-helper: ERROR: could not mount boot partition for customization"
-  fi
+    OFFSET=$((PART1_START * 512))
+
+    LOOP_DEV=$("$BUSYBOX" losetup -f)
+    "$BUSYBOX" losetup -o "$OFFSET" "$LOOP_DEV" "$TARGET_DEV"
+
+    "$BUSYBOX" mkdir -p /dev/shm/bootmnt
+    if "$BUSYBOX" mount -t vfat "$LOOP_DEV" /dev/shm/bootmnt; then
+      [ -f /dev/shm/custom-user-data ] && \
+        "$BUSYBOX" cp /dev/shm/custom-user-data /dev/shm/bootmnt/user-data
+      [ -f /dev/shm/custom-network-config ] && \
+        "$BUSYBOX" cp /dev/shm/custom-network-config /dev/shm/bootmnt/network-config
+      # Update regulatory domain in cmdline.txt to match WiFi country
+      if [ -f /dev/shm/custom-wifi-country ] && [ -f /dev/shm/bootmnt/cmdline.txt ]; then
+        REGDOM=$("$BUSYBOX" cat /dev/shm/custom-wifi-country | "$BUSYBOX" tr -d '[:space:]')
+        "$BUSYBOX" sed -i "s/cfg80211.ieee80211_regdom=[A-Z]*/cfg80211.ieee80211_regdom=$REGDOM/" /dev/shm/bootmnt/cmdline.txt
+      fi
+      "$BUSYBOX" umount /dev/shm/bootmnt
+      echo "flash-helper: boot partition customization applied"
+    else
+      echo "flash-helper: ERROR: could not mount boot partition for customization"
+    fi
+    "$BUSYBOX" losetup -d "$LOOP_DEV" 2>/dev/null || true
+  ) || echo "flash-helper: WARNING: customization failed, continuing to reboot"
 fi
 
 echo "flash-helper: rebooting..."

--- a/flash-live-remote
+++ b/flash-live-remote
@@ -10,17 +10,64 @@ _require() {
   done
 }
 
+# --- Config file parser ---
+
+parse_config() {
+  local config_file="$1"
+  if [ ! -f "$config_file" ]; then
+    echo "Error: config file not found: $config_file" >&2
+    exit 1
+  fi
+  while IFS= read -r line || [ -n "$line" ]; do
+    # Skip blank lines and comments
+    [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
+    key="${line%%=*}"
+    value="${line#*=}"
+    # Trim whitespace from key
+    key=$(echo "$key" | tr -d '[:space:]')
+    # Expand leading ~/ to $HOME/ (shell doesn't expand tildes in file content)
+    value="${value/#\~\//$HOME/}"
+    case "$key" in
+      hostname)      custom_hostname="$value" ;;
+      user)          custom_user="$value" ;;
+      password)      custom_password="$value" ;;
+      ssh-key)       custom_ssh_keys+=("$value") ;;
+      wifi-ssid)     wifi_ssid="$value" ;;
+      wifi-password) wifi_password="$value" ;;
+      wifi-country)  wifi_country="$value" ;;
+      *)
+        echo "Error: unknown config key '$key' in $config_file" >&2
+        exit 1
+        ;;
+    esac
+  done < "$config_file"
+}
+
 # --- Argument parsing ---
 
 mode="ramfs"
+custom_hostname=""
+custom_user=""
+custom_password=""
+custom_ssh_keys=()
+wifi_ssid=""
+wifi_password=""
+wifi_country="GB"
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --ramfs)  mode="ramfs";  shift ;;
     --stream) mode="stream"; shift ;;
+    --config)
+      if [ $# -lt 2 ]; then
+        echo "Error: --config requires a file path" >&2
+        exit 1
+      fi
+      parse_config "$2"; shift 2 ;;
     -*)
       echo "Error: unknown option '$1'" >&2
       echo "" >&2
-      echo "Usage: flash-live-remote [--ramfs|--stream] <host> <image>" >&2
+      echo "Usage: flash-live-remote [--ramfs|--stream] [--config FILE] <host> <image>" >&2
       exit 1
       ;;
     *) break ;;
@@ -28,24 +75,31 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [ $# -lt 2 ]; then
-  echo "Usage: flash-live-remote [--ramfs|--stream] <host> <image>" >&2
+  echo "Usage: flash-live-remote [--ramfs|--stream] [--config FILE] <host> <image>" >&2
   echo "" >&2
   echo "Flash an image to a remote Linux device over the network." >&2
   echo "The device must be running and accessible via SSH." >&2
   echo "" >&2
   echo "Modes:" >&2
-  echo "  --ramfs   (default) scp image to /dev/shm, then decompress+dd locally" >&2
-  echo "  --stream  Stream image directly over SSH (for low-memory devices)" >&2
+  echo "  --ramfs            (default) scp image to /dev/shm, then decompress+dd locally" >&2
+  echo "  --stream           Stream image directly over SSH (for low-memory devices)" >&2
+  echo "" >&2
+  echo "First-boot customization:" >&2
+  echo "  --config FILE      Config file with key=value settings for first-boot customization." >&2
+  echo "                     See example.conf for available keys and format." >&2
+  echo "                     Requires the new image to have the same partition layout as the" >&2
+  echo "                     running image (boot partition = partition 1)." >&2
   echo "" >&2
   echo "Supported formats: .img, .img.xz, .img.gz" >&2
   echo "" >&2
   echo "Examples:" >&2
   echo "  flash-live-remote halos.local image.img.xz" >&2
+  echo "  flash-live-remote --config myboat.conf halos.local image.img.xz" >&2
   echo "  flash-live-remote --stream pi@192.168.1.100 image.img" >&2
   echo "" >&2
   echo "Prerequisites:" >&2
   echo "  Local:  ssh, scp, xzcat/zcat (for compressed images)" >&2
-  echo "  Target: busybox, SSH access" >&2
+  echo "  Target: busybox (with mount, umount applets for customization)" >&2
   exit 1
 fi
 
@@ -89,6 +143,125 @@ image_size_mb=$((image_size / 1048576))
 size_label="on-disk"
 if [[ "$image" == *.img.xz ]] || [[ "$image" == *.img.gz ]]; then
   size_label="compressed"
+fi
+
+# --- Validate customization flags ---
+
+if [ -n "$custom_hostname" ] && ! [[ "$custom_hostname" =~ ^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$ ]]; then
+  echo "Error: hostname must contain only alphanumeric characters and hyphens" >&2
+  exit 1
+fi
+if [ -n "$custom_user" ] && ! [[ "$custom_user" =~ ^[a-z_][a-z0-9_-]*$ ]]; then
+  echo "Error: username must be a valid Linux username (lowercase, alphanumeric, hyphens, underscores)" >&2
+  exit 1
+fi
+if [ -n "$wifi_country" ] && ! [[ "$wifi_country" =~ ^[A-Z]{2}$ ]]; then
+  echo "Error: wifi-country must be a 2-letter country code (e.g., GB, US, FI)" >&2
+  exit 1
+fi
+if [ -n "$wifi_ssid" ] && [ -z "$wifi_password" ]; then
+  echo "Error: wifi-ssid requires wifi-password" >&2
+  exit 1
+fi
+if [ -n "$wifi_password" ] && [ -z "$wifi_ssid" ]; then
+  echo "Error: wifi-password requires wifi-ssid" >&2
+  exit 1
+fi
+if [ -n "$custom_password" ] && [ -z "$custom_user" ]; then
+  echo "Error: password requires user" >&2
+  exit 1
+fi
+
+# If user given without explicit ssh-key, auto-detect local SSH public keys
+if [ -n "$custom_user" ] && [ ${#custom_ssh_keys[@]} -eq 0 ]; then
+  for pubkey in ~/.ssh/*.pub; do
+    [ -f "$pubkey" ] && custom_ssh_keys+=("$pubkey")
+  done
+fi
+
+if [ -n "$custom_user" ] && [ -z "$custom_password" ] && [ ${#custom_ssh_keys[@]} -eq 0 ]; then
+  echo "Warning: user set but no password or SSH keys found. User will have no authentication method." >&2
+  echo "  Add password or ssh-key to your config file, or place public keys in ~/.ssh/*.pub" >&2
+fi
+
+# If password given, hash it locally
+password_hash=""
+if [ -n "$custom_password" ]; then
+  _require openssl
+  password_hash=$(echo "$custom_password" | openssl passwd -6 -stdin)
+fi
+
+has_customization=false
+if [ -n "$custom_hostname" ] || [ -n "$custom_user" ] || [ -n "$wifi_ssid" ]; then
+  has_customization=true
+fi
+
+# --- Generate first-boot payloads ---
+# Follows the cloudinit-rpi format used by RPi Imager 2.x:
+# - user-data: cloud-init YAML with users: block, hostname, ssh_pwauth
+# - network-config: netplan YAML with eth0 + optional wlan0
+
+custom_user_data=""
+custom_network_config=""
+
+# Build user-data YAML matching RPi Imager's cloudinit-rpi format
+ud_lines=()
+ud_lines+=("#cloud-config")
+
+if [ -n "$custom_hostname" ]; then
+  ud_lines+=("hostname: $custom_hostname")
+  ud_lines+=("manage_etc_hosts: true")
+fi
+
+if [ -n "$custom_user" ]; then
+  # Read SSH public keys
+  ssh_key_lines=()
+  for keyfile in "${custom_ssh_keys[@]}"; do
+    if [ ! -f "$keyfile" ]; then
+      echo "Error: SSH key file not found: $keyfile" >&2
+      exit 1
+    fi
+    ssh_key_lines+=("$(head -1 "$keyfile")")
+  done
+
+  ud_lines+=("users:")
+  ud_lines+=("  - name: $custom_user")
+  ud_lines+=("    groups: users,adm,dialout,audio,netdev,video,plugdev,cdrom,games,input,gpio,spi,i2c,render,sudo")
+  ud_lines+=("    shell: /bin/bash")
+  ud_lines+=("    sudo: ALL=(ALL) NOPASSWD:ALL")
+  if [ -n "$password_hash" ]; then
+    ud_lines+=("    lock_passwd: false")
+    ud_lines+=("    passwd: $password_hash")
+  fi
+  if [ ${#ssh_key_lines[@]} -gt 0 ]; then
+    ud_lines+=("    ssh_authorized_keys:")
+    for key in "${ssh_key_lines[@]}"; do
+      ud_lines+=("      - $key")
+    done
+  fi
+  ud_lines+=("enable_ssh: true")
+  ud_lines+=("ssh_pwauth: true")
+fi
+
+# Only produce user-data if there's more than just the #cloud-config header
+if [ ${#ud_lines[@]} -gt 1 ]; then
+  custom_user_data=$(printf '%s\n' "${ud_lines[@]}")
+fi
+
+if [ -n "$wifi_ssid" ]; then
+  # cloud-init treats network-config as the complete network definition,
+  # so we must include eth0 — otherwise wired ethernet loses DHCP.
+  custom_network_config="network:
+  version: 2
+  wifis:
+    renderer: NetworkManager
+    wlan0:
+      dhcp4: true
+      regulatory-domain: \"$wifi_country\"
+      access-points:
+        \"$wifi_ssid\":
+          password: \"$wifi_password\"
+      optional: true"
 fi
 
 # Mode-specific local prerequisites
@@ -155,6 +328,17 @@ if [ "$mode" = "ramfs" ]; then
   fi
 fi
 
+# Preflight checks for customization capabilities on target
+if [ "$has_customization" = true ]; then
+  echo "Checking customization prerequisites on target..."
+
+  # Verify kernel supports vfat
+  if ! ssh -n "$host" "grep -q vfat /proc/filesystems"; then
+    echo "Error: kernel on $host lacks vfat support (required for customization)" >&2
+    exit 1
+  fi
+fi
+
 # --- Confirmation prompt ---
 
 echo ""
@@ -163,6 +347,18 @@ echo "  Target device: $root_dev (~${dev_size_gb} GB)"
 echo "  Root partition: $root_part"
 echo "  Image file: $image (${image_size_mb} MB ${size_label})"
 echo "  Target host: $host"
+if [ "$has_customization" = true ]; then
+  echo ""
+  echo "  First-boot customization:"
+  [ -n "$custom_hostname" ] && echo "    Hostname: $custom_hostname"
+  if [ -n "$custom_user" ]; then
+    user_info="$custom_user"
+    [ -n "$custom_password" ] && user_info+=" (with password)"
+    [ ${#custom_ssh_keys[@]} -gt 0 ] && user_info+=" (with ${#custom_ssh_keys[@]} SSH key(s))"
+    echo "    User: $user_info"
+  fi
+  [ -n "$wifi_ssid" ] && echo "    WiFi: $wifi_ssid (country: $wifi_country)"
+fi
 echo ""
 echo "WARNING: This will ERASE ALL DATA on $root_dev on $host."
 echo "The device will be unreachable during flashing and will reboot when done."
@@ -171,6 +367,19 @@ read -r -p "Type 'yes' to proceed: " confirm
 if [ "$confirm" != "yes" ]; then
   echo "Aborted."
   exit 1
+fi
+
+# Transfer customization payloads to target (after confirmation to avoid
+# leaving sensitive data on target if the user aborts)
+if [ "$has_customization" = true ]; then
+  echo ""
+  echo "Transferring customization payloads..."
+  if [ -n "$custom_user_data" ]; then
+    echo "$custom_user_data" | ssh "$host" "cat > /dev/shm/custom-user-data"
+  fi
+  if [ -n "$custom_network_config" ]; then
+    echo "$custom_network_config" | ssh "$host" "cat > /dev/shm/custom-network-config"
+  fi
 fi
 
 # --- Ramfs mode ---
@@ -228,6 +437,35 @@ echo "flash-helper: dd complete:"
 
 "$BUSYBOX" rm -f "$IMAGE_PATH"
 
+# Apply first-boot customization if payload files were transferred.
+# Errors here must not abort — the image is already flashed successfully,
+# so we want to reboot regardless.
+if [ -f /dev/shm/custom-user-data ] || [ -f /dev/shm/custom-network-config ]; then
+  echo "flash-helper: applying first-boot customization..."
+
+  # Determine boot partition device name (mmcblk0p1 vs sda1).
+  # The kernel's old partition nodes are still valid — dd wrote a new
+  # partition table with the same layout, and the kernel keeps the stale
+  # entries until reboot. No blockdev --rereadpt needed (and it would
+  # fail anyway since the rootfs partition is still "in use").
+  BOOT_PART="${TARGET_DEV}p1"
+  "$BUSYBOX" test -b "$BOOT_PART" || BOOT_PART="${TARGET_DEV}1"
+
+  "$BUSYBOX" mkdir -p /dev/shm/bootmnt
+  if "$BUSYBOX" mount -t vfat "$BOOT_PART" /dev/shm/bootmnt; then
+    [ -f /dev/shm/custom-user-data ] && \
+      "$BUSYBOX" cp /dev/shm/custom-user-data /dev/shm/bootmnt/user-data
+    [ -f /dev/shm/custom-network-config ] && \
+      "$BUSYBOX" cp /dev/shm/custom-network-config /dev/shm/bootmnt/network-config
+    # umount flushes FAT32 data. No explicit sync — a global sync would risk
+    # writing back old rootfs dirty pages over the new image.
+    "$BUSYBOX" umount /dev/shm/bootmnt
+    echo "flash-helper: boot partition customization applied"
+  else
+    echo "flash-helper: ERROR: could not mount boot partition for customization"
+  fi
+fi
+
 # EXIT trap handles reboot -f (skips sync so old rootfs cache doesn't
 # write back over the new image).
 echo "flash-helper: rebooting..."
@@ -269,7 +507,30 @@ trap '"$BUSYBOX" reboot -f' EXIT
 echo "flash-helper: writing stdin -> $TARGET_DEV"
 "$DD" of="$TARGET_DEV" bs=4M 2>/dev/shm/dd-status
 "$BUSYBOX" cat /dev/shm/dd-status 2>/dev/null || true
-echo "flash-helper: dd complete, rebooting..."
+echo "flash-helper: dd complete"
+
+# Apply first-boot customization if payload files were transferred
+if [ -f /dev/shm/custom-user-data ] || [ -f /dev/shm/custom-network-config ]; then
+  echo "flash-helper: applying first-boot customization..."
+
+  # See ramfs helper for explanation of why blockdev --rereadpt is skipped.
+  BOOT_PART="${TARGET_DEV}p1"
+  "$BUSYBOX" test -b "$BOOT_PART" || BOOT_PART="${TARGET_DEV}1"
+
+  "$BUSYBOX" mkdir -p /dev/shm/bootmnt
+  if "$BUSYBOX" mount -t vfat "$BOOT_PART" /dev/shm/bootmnt; then
+    [ -f /dev/shm/custom-user-data ] && \
+      "$BUSYBOX" cp /dev/shm/custom-user-data /dev/shm/bootmnt/user-data
+    [ -f /dev/shm/custom-network-config ] && \
+      "$BUSYBOX" cp /dev/shm/custom-network-config /dev/shm/bootmnt/network-config
+    "$BUSYBOX" umount /dev/shm/bootmnt
+    echo "flash-helper: boot partition customization applied"
+  else
+    echo "flash-helper: ERROR: could not mount boot partition for customization"
+  fi
+fi
+
+echo "flash-helper: rebooting..."
 HELPER_EOF
 
   ssh -n "$host" "chmod +x /dev/shm/flash-helper.sh"

--- a/flash-live-remote
+++ b/flash-live-remote
@@ -244,6 +244,8 @@ fi
 # Only produce user-data if there's more than just the #cloud-config header
 if [ ${#ud_lines[@]} -gt 1 ]; then
   custom_user_data=$(printf '%s\n' "${ud_lines[@]}")
+  # NoCloud datasource requires meta-data to exist (even if minimal)
+  custom_meta_data="instance-id: flash-live-remote-$(date +%s)"
 fi
 
 if [ -n "$wifi_ssid" ]; then
@@ -393,6 +395,7 @@ if [ "$has_customization" = true ]; then
   echo "Transferring customization payloads..."
   if [ -n "$custom_user_data" ]; then
     echo "$custom_user_data" | ssh "$host" "cat > /dev/shm/custom-user-data"
+    echo "$custom_meta_data" | ssh "$host" "cat > /dev/shm/custom-meta-data"
   fi
   if [ -n "$custom_network_config" ]; then
     echo "$custom_network_config" | ssh "$host" "cat > /dev/shm/custom-network-config"
@@ -495,6 +498,8 @@ if [ -f /dev/shm/custom-user-data ] || [ -f /dev/shm/custom-network-config ]; th
     if "$BUSYBOX" mount -t vfat "$LOOP_DEV" /dev/shm/bootmnt; then
       [ -f /dev/shm/custom-user-data ] && \
         "$BUSYBOX" cp /dev/shm/custom-user-data /dev/shm/bootmnt/user-data
+      [ -f /dev/shm/custom-meta-data ] && \
+        "$BUSYBOX" cp /dev/shm/custom-meta-data /dev/shm/bootmnt/meta-data
       [ -f /dev/shm/custom-network-config ] && \
         "$BUSYBOX" cp /dev/shm/custom-network-config /dev/shm/bootmnt/network-config
       # Update regulatory domain in cmdline.txt to match WiFi country
@@ -586,6 +591,8 @@ if [ -f /dev/shm/custom-user-data ] || [ -f /dev/shm/custom-network-config ]; th
     if "$BUSYBOX" mount -t vfat "$LOOP_DEV" /dev/shm/bootmnt; then
       [ -f /dev/shm/custom-user-data ] && \
         "$BUSYBOX" cp /dev/shm/custom-user-data /dev/shm/bootmnt/user-data
+      [ -f /dev/shm/custom-meta-data ] && \
+        "$BUSYBOX" cp /dev/shm/custom-meta-data /dev/shm/bootmnt/meta-data
       [ -f /dev/shm/custom-network-config ] && \
         "$BUSYBOX" cp /dev/shm/custom-network-config /dev/shm/bootmnt/network-config
       # Update regulatory domain in cmdline.txt to match WiFi country

--- a/flash-live-remote
+++ b/flash-live-remote
@@ -249,18 +249,29 @@ if [ ${#ud_lines[@]} -gt 1 ]; then
 fi
 
 if [ -n "$wifi_ssid" ]; then
-  # cloud-init treats network-config as the complete network definition,
-  # so we must include eth0 — otherwise wired ethernet loses DHCP.
+  # Compute WPA PSK from passphrase + SSID (avoids plaintext password on disk)
+  _require python3
+  wifi_psk=$(python3 -c "
+import hashlib, sys
+psk = hashlib.pbkdf2_hmac('sha1', sys.argv[1].encode(), sys.argv[2].encode(), 4096, 32)
+print(psk.hex())
+" "$wifi_password" "$wifi_ssid")
+
+  # Match RPi Imager's network-config format exactly
   custom_network_config="network:
   version: 2
+  ethernets:
+    eth0:
+      dhcp4: true
+      dhcp6: true
+      optional: true
   wifis:
-    renderer: NetworkManager
     wlan0:
       dhcp4: true
       regulatory-domain: \"$wifi_country\"
       access-points:
         \"$wifi_ssid\":
-          password: \"$wifi_password\"
+          password: \"$wifi_psk\"
       optional: true"
 fi
 
@@ -379,6 +390,7 @@ if [ "$has_customization" = true ]; then
   fi
   if [ -n "$custom_network_config" ]; then
     echo "$custom_network_config" | ssh "$host" "cat > /dev/shm/custom-network-config"
+    echo "$wifi_country" | ssh "$host" "cat > /dev/shm/custom-wifi-country"
   fi
 fi
 
@@ -457,6 +469,11 @@ if [ -f /dev/shm/custom-user-data ] || [ -f /dev/shm/custom-network-config ]; th
       "$BUSYBOX" cp /dev/shm/custom-user-data /dev/shm/bootmnt/user-data
     [ -f /dev/shm/custom-network-config ] && \
       "$BUSYBOX" cp /dev/shm/custom-network-config /dev/shm/bootmnt/network-config
+    # Update regulatory domain in cmdline.txt to match WiFi country
+    if [ -f /dev/shm/custom-wifi-country ] && [ -f /dev/shm/bootmnt/cmdline.txt ]; then
+      REGDOM=$("$BUSYBOX" cat /dev/shm/custom-wifi-country | "$BUSYBOX" tr -d '[:space:]')
+      "$BUSYBOX" sed -i "s/cfg80211.ieee80211_regdom=[A-Z]*/cfg80211.ieee80211_regdom=$REGDOM/" /dev/shm/bootmnt/cmdline.txt
+    fi
     # umount flushes FAT32 data. No explicit sync — a global sync would risk
     # writing back old rootfs dirty pages over the new image.
     "$BUSYBOX" umount /dev/shm/bootmnt
@@ -523,6 +540,11 @@ if [ -f /dev/shm/custom-user-data ] || [ -f /dev/shm/custom-network-config ]; th
       "$BUSYBOX" cp /dev/shm/custom-user-data /dev/shm/bootmnt/user-data
     [ -f /dev/shm/custom-network-config ] && \
       "$BUSYBOX" cp /dev/shm/custom-network-config /dev/shm/bootmnt/network-config
+    # Update regulatory domain in cmdline.txt to match WiFi country
+    if [ -f /dev/shm/custom-wifi-country ] && [ -f /dev/shm/bootmnt/cmdline.txt ]; then
+      REGDOM=$("$BUSYBOX" cat /dev/shm/custom-wifi-country | "$BUSYBOX" tr -d '[:space:]')
+      "$BUSYBOX" sed -i "s/cfg80211.ieee80211_regdom=[A-Z]*/cfg80211.ieee80211_regdom=$REGDOM/" /dev/shm/bootmnt/cmdline.txt
+    fi
     "$BUSYBOX" umount /dev/shm/bootmnt
     echo "flash-helper: boot partition customization applied"
   else


### PR DESCRIPTION
## Summary

- Add `--config FILE` option for first-boot customization (hostname, user, password, SSH keys, WiFi)
- Generate cloud-init `user-data` and `network-config` matching RPi Imager format
- Mount boot partition via loop device at correct LBA offset to avoid stale kernel partition cache after dd
- Copy busybox to tmpfs before dd to prevent SIGBUS from page eviction

Closes #3

## Commits

1. **feat: add first-boot customization via --config FILE** — config parser, cloud-init payload generation, boot partition write
2. **fix: match RPi Imager network-config format** — WPA PSK hashing, eth0 DHCP, regulatory domain in cmdline.txt
3. **fix: prevent hang when flashing with --config** — busybox tmpfs copy, loop device mount with fdisk-parsed offset, sysrq reboot fallback, applet preflight checks

## Test plan

- [x] Flash HaLOS image with `--config` (ramfs mode) — device reboots, cloud-init config applied
- [x] Verified `user-data` and `network-config` on boot partition match RPi Imager reference format
- [x] Verified hostname, user, WiFi credentials applied on first boot
- [ ] Flash with `--config` in stream mode
- [ ] Flash without `--config` — verify no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)