### PR TITLE
Update installation URLs after repo rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ Flash a Linux SBC — locally on the device itself or over the network. Transfer
 
 ```bash
 # Clone and symlink
-git clone https://github.com/hatlabs/flash-live-remote.git
-ln -s "$PWD/flash-live-remote/flash-live-system" /usr/local/bin/
+git clone https://github.com/hatlabs/flash-live-system.git
+ln -s "$PWD/flash-live-system/flash-live-system" /usr/local/bin/
 
 # Or just download the script
 curl -o /usr/local/bin/flash-live-system \
-  https://raw.githubusercontent.com/hatlabs/flash-live-remote/main/flash-live-system
+  https://raw.githubusercontent.com/hatlabs/flash-live-system/main/flash-live-system
 chmod +x /usr/local/bin/flash-live-system
 ```
 


### PR DESCRIPTION
## Summary

- Update clone URL and raw download URL in README to reflect the repo rename from `flash-live-remote` to `flash-live-system`

🤖 Generated with [Claude Code](https://claude.com/claude-code)