### PR TITLE
Update version-bump-check to per-release policy

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -50,34 +50,45 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check VERSION changed
+      - name: Check VERSION bumped since last stable release
         run: |
           BASE_SHA=$(git merge-base origin/main HEAD)
           CHANGED_FILES=$(git diff --name-only "$BASE_SHA"...HEAD)
 
-          # Filter to package-affecting files using the same exclusion
-          # patterns as shared-workflows/pr-checks.yml
-          PACKAGE_FILES=$(echo "$CHANGED_FILES" \
-            | grep -v -E '^(VERSION$|.*\.md$|docs/|\.github/|\.devcontainer/|\.vscode/|\.claude/)' \
-            | grep -v -E '^(lefthook\.yml$|\.bumpversion\.cfg$|\.gitignore$|\.editorconfig$|LICENSE)' \
-            | grep -v -E '^(tests?/|__tests__/|e2e/|.*\.test\.[^/]+$|.*\.spec\.[^/]+$)' \
-            | grep -v -E '^(docker/|Dockerfile|docker-compose|config\.)' \
-            | grep -v -E '^(tools/|run$|Makefile$|Taskfile\.yml$)' \
-            | grep -v -E '\.(lock)$' \
-            | grep -v -E '\.lintian-overrides$' \
-            || true)
+          CURRENT_VERSION=$(cat VERSION | tr -d '[:space:]')
 
-          if [ -n "$PACKAGE_FILES" ]; then
-            if ! echo "$CHANGED_FILES" | grep -q '^VERSION$'; then
-              echo "::error::Package-affecting files changed but VERSION was not bumped."
-              echo ""
-              echo "Changed package files:"
-              echo "$PACKAGE_FILES" | sed 's/^/  /'
-              echo ""
-              echo "Update VERSION (e.g., echo '0.2.0' > VERSION)"
-              exit 1
+          # Find latest stable tag (v{upstream}+{revision}, no _pre suffix)
+          LATEST_STABLE_TAG=$(git tag -l 'v*' \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?\+[0-9]+$' \
+            | sort -V | tail -1 || true)
+
+          if [ -n "$LATEST_STABLE_TAG" ]; then
+            TAGGED_VERSION=$(echo "$LATEST_STABLE_TAG" | sed 's/^v\(.*\)+[0-9]*$/\1/')
+
+            if [ "$CURRENT_VERSION" != "$TAGGED_VERSION" ]; then
+              echo "VERSION ($CURRENT_VERSION) differs from latest stable release ($TAGGED_VERSION) — no bump needed"
+            else
+              # VERSION matches latest stable tag — check if package-affecting files changed
+              PACKAGE_FILES=$(echo "$CHANGED_FILES" \
+                | grep -v -E '^(VERSION$|.*\.md$|docs/|\.github/|\.devcontainer/|\.vscode/|\.claude/)' \
+                | grep -v -E '^(lefthook\.yml$|\.bumpversion\.cfg$|\.gitignore$|\.editorconfig$|LICENSE)' \
+                | grep -v -E '^(tests?/|__tests__/|e2e/|.*\.test\.[^/]+$|.*\.spec\.[^/]+$)' \
+                | grep -v -E '^(docker/|Dockerfile|docker-compose|config\.)' \
+                | grep -v -E '^(tools/|run$|Makefile$|Taskfile\.yml$)' \
+                | grep -v -E '\.(lock)$' \
+                | grep -v -E '\.lintian-overrides$' \
+                || true)
+
+              if [ -n "$PACKAGE_FILES" ]; then
+                echo "::error::Package-affecting files changed but VERSION ($CURRENT_VERSION) still matches the latest stable release ($LATEST_STABLE_TAG)."
+                echo ""
+                echo "Changed package files:"
+                echo "$PACKAGE_FILES" | sed 's/^/  /'
+                echo ""
+                echo "VERSION needs to be bumped before the next release."
+                exit 1
+              fi
             fi
-            echo "VERSION file updated — OK"
           else
-            echo "Only non-package files changed, no version bump needed"
+            echo "No stable release tags found — skipping version check"
           fi


### PR DESCRIPTION
## Summary

- Replace per-PR version bump requirement with tag-based check
- VERSION only needs to be bumped once between stable releases, not on every PR
- Gracefully skips when no stable tags exist yet

Aligns with the per-release policy adopted in shared-workflows (halos-org/shared-workflows#19).

Fixes #18

## Test plan

- [ ] PR with package-affecting files and no stable tags — should pass (skip)
- [ ] PR where VERSION already differs from latest stable tag — should pass
- [ ] PR where VERSION matches latest stable tag and package files changed — should fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)