### PR TITLE
Fix YAML parsing error in main workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,21 +113,20 @@ jobs:
           TAG="v${VERSION}+${REVISION}"
           git tag "$TAG"
           git push origin "$TAG"
-          NOTES="$(cat <<NOTES
-## flash-live-system $TAG
-
-Built from $(git rev-parse --short HEAD).
-
-### Installation
-
-\`\`\`bash
-curl -Lo /usr/local/bin/flash-live-system \\
-  https://github.com/${{ github.repository }}/releases/download/${TAG}/flash-live-system
-chmod +x /usr/local/bin/flash-live-system
-\`\`\`
-NOTES
-          )"
+          {
+            echo "## flash-live-system $TAG"
+            echo ""
+            echo "Built from $(git rev-parse --short HEAD)."
+            echo ""
+            echo "### Installation"
+            echo ""
+            echo '```bash'
+            echo "curl -Lo /usr/local/bin/flash-live-system \\"
+            echo "  https://github.com/${{ github.repository }}/releases/download/${TAG}/flash-live-system"
+            echo "chmod +x /usr/local/bin/flash-live-system"
+            echo '```'
+          } > /tmp/release-notes.md
           gh release create "$TAG" dist/flash-live-system \
             --title "$TAG" \
             --draft \
-            --notes "$NOTES"
+            --notes-file /tmp/release-notes.md


### PR DESCRIPTION
## Summary

- The "Create draft stable release" step used a shell heredoc whose body had zero indentation inside a YAML block scalar (`|`) requiring 10 spaces of indentation
- This caused GitHub Actions to fail at YAML parse time — no jobs ever started
- The workflow has never successfully run since it was created
- Replace the heredoc with `echo` statements writing to a temp file, used via `--notes-file`

## Test plan

- [ ] PR checks pass (validates YAML is parseable)
- [ ] After merge, the `main.yml` workflow should start and execute jobs instead of failing immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)