### PR TITLE
Remove unnecessary drop_caches, fix version-bump-check for draft releases

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -57,8 +57,10 @@ jobs:
 
           CURRENT_VERSION=$(cat VERSION | tr -d '[:space:]')
 
-          # Find latest stable tag (v{upstream}+{revision}, no _pre suffix)
-          LATEST_STABLE_TAG=$(git tag -l 'v*' \
+          # Find latest published stable release (excludes drafts and pre-releases).
+          # Draft releases create git tags, so git tag -l alone is insufficient.
+          LATEST_STABLE_TAG=$(gh release list --exclude-drafts --exclude-pre-releases \
+            --json tagName --jq '.[].tagName' \
             | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?\+[0-9]+$' \
             | sort -V | tail -1 || true)
 

--- a/flash-live-system
+++ b/flash-live-system
@@ -630,12 +630,6 @@ fi
 
 echo "apply-customization: applying first-boot customization..."
 
-# Drop all page caches before interacting with the block device. After dd,
-# the kernel may still hold stale dirty pages from the old filesystem (ext4
-# journal, metadata). A loop mount + umount on the same block device can
-# trigger writeback of those stale pages, corrupting the new image.
-echo 3 > /proc/sys/vm/drop_caches 2>/dev/null || true
-
 # Mount via loop device at the correct offset from the NEW partition table.
 # After dd, the kernel still has stale partition nodes (old offsets/sizes)
 # and stale block cache from the old image. Using the partition node would


### PR DESCRIPTION
## Summary

- Remove `echo 3 > /proc/sys/vm/drop_caches` from `apply-customization.sh` — testing confirmed the emergency remount read-only (SysRq-u) is the actual fix for the Bookworm corruption
- Fix version-bump-check to use `gh release list --exclude-drafts` instead of `git tag -l` — draft releases create git tags, causing false positives in repos with no published releases

## Test plan

- [x] Flash HaLOS from OpenPlotter (Bookworm kernel 6.6) without `drop_caches` — boots successfully
- [ ] Version-bump-check passes (no published stable releases exist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)