### PR TITLE
fix(ci): don't create git tags for draft releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,6 +101,10 @@ jobs:
           gh release list --json tagName,isDraft --jq '.[] | select(.isDraft) | .tagName' | while read -r tag; do
             echo "Deleting old draft release: $tag"
             gh release delete "$tag" --yes 2>/dev/null || true
+            if git ls-remote --tags origin "refs/tags/$tag" | grep -q .; then
+              echo "Deleting orphaned tag: $tag"
+              git push origin --delete "$tag" 2>/dev/null || true
+            fi
           done
 
       - name: Create draft stable release
@@ -111,8 +115,6 @@ jobs:
           REVISION: ${{ steps.revision.outputs.revision }}
         run: |
           TAG="v${VERSION}+${REVISION}"
-          git tag "$TAG"
-          git push origin "$TAG"
           {
             echo "## flash-live-system $TAG"
             echo ""
@@ -129,4 +131,5 @@ jobs:
           gh release create "$TAG" dist/flash-live-system \
             --title "$TAG" \
             --draft \
+            --target $(git rev-parse HEAD) \
             --notes-file /tmp/release-notes.md


### PR DESCRIPTION
## Summary

- Remove premature git tag creation from the draft stable release step; use `--target` with `gh release create` so the tag is only created when the draft is published
- Clean up orphaned tags when deleting old draft releases

closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)