### PR TITLE
Switch to text console before flashing in remote ramfs mode

### DIFF
--- a/flash-live-system
+++ b/flash-live-system
@@ -700,12 +700,15 @@ deploy_ramfs_helper() {
 #!/bin/bash
 
 # Phase 1 — runs under /bin/bash from rootfs (safe: dd hasn't started yet).
-# Re-exec under busybox sh from tmpfs so that NOTHING running after dd
+# Switch to a text console so output is visible on the physical display
+# (also serves as a clear visual signal that something drastic is happening).
+# Then re-exec under busybox sh from tmpfs so that NOTHING running after dd
 # depends on rootfs pages. Output is piped through tee so it appears on
 # both /dev/console (physical display) and /dev/shm/flash-helper.log.
 
 if [ -z "$_FLASH_REEXEC" ]; then
   export _FLASH_REEXEC=1
+  chvt 1 2>/dev/null || true
   exec /dev/shm/busybox sh -c \
     '/dev/shm/busybox sh "$0" "$@" 2>&1 | /dev/shm/busybox tee /dev/shm/flash-helper.log > /dev/console' \
     "$0" "$@"


### PR DESCRIPTION
## Summary

- Adds `chvt 1` in the ramfs helper's Phase 1 (before re-exec) to switch the physical display from a graphical desktop to the text console
- Ensures flash progress output (already piped to `/dev/console` via tee) is visible on the device's monitor
- Provides a clear visual signal that something drastic is happening with the machine
- Silently ignored on headless devices or when VTs are unavailable

## Test plan

- [ ] Flash a device running a graphical desktop via `--remote` ramfs mode — verify the display switches to a text console and shows flash progress
- [ ] Flash a headless device via `--remote` ramfs mode — verify no errors from the `chvt` call
- [ ] Verify local modes are unaffected (no changes to local helper scripts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)