### PR TITLE
Fix CI revision counter to avoid tag collisions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,11 +28,16 @@ jobs:
       - name: Calculate revision
         id: revision
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          # Count existing tags matching v{VERSION}+*
-          COUNT=$(git tag -l "v${VERSION}+*" | wc -l | tr -d ' ')
+          # Revision = number of commits since VERSION was last changed.
+          # Each merge to main produces a unique count, avoiding tag collisions.
+          LAST_CHANGE=$(git log -1 --format=%H -- VERSION)
+          if [ -z "$LAST_CHANGE" ]; then
+            echo "ERROR: cannot find commit that last changed VERSION"
+            exit 1
+          fi
+          COUNT=$(git rev-list --count "${LAST_CHANGE}..HEAD")
           echo "revision=$COUNT" >> "$GITHUB_OUTPUT"
-          echo "Version: $VERSION, Revision: $COUNT"
+          echo "Version: ${{ steps.version.outputs.version }}, Revision: $COUNT"
 
       - name: Check if pre-release already exists
         id: check-prerelease


### PR DESCRIPTION
## Summary

- Replace tag-count-based revision with `git rev-list --count` from the last VERSION change
- Fixes skipped builds when multiple PRs merge at the same VERSION (tag already exists → skip)

## Root cause

The revision was calculated as `git tag -l "v${VERSION}+*" | wc -l`. When a build created tags (e.g., `v0.2.0+4_pre`), subsequent merges at the same VERSION computed the same count (4) and found the tag already existed, skipping the build entirely.

PRs #29 and #30 both had their builds skipped because of this.

## Fix

Count commits since VERSION was last changed. Each merge to main adds at least one commit, so the revision is always unique and monotonically increasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)